### PR TITLE
Update mimemagic dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -434,4 +436,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.6
+   1.17.3


### PR DESCRIPTION
`mimemagic` in older versions required projects to be under the General
Public License. It came to light recently and it was a mistake of the
mimemagic's package creator.

We do not want the project to be kept under GPL license, so we upgrade
the dependency so as to allow ourselves to keep it under MIT one.

Resolves https://github.com/michudzik/dissertation/issues/2